### PR TITLE
Add server-side survey date validation

### DIFF
--- a/src/__tests__/surveys/surveys.test.ts
+++ b/src/__tests__/surveys/surveys.test.ts
@@ -144,6 +144,20 @@ describe('POST /api/surveys', () => {
     expect(data.error).toBe('候補日の日付を入力してください');
   });
 
+  it('should return 400 when surveyDate has invalid date format', async () => {
+    const request = createMockRequest({
+      schoolYearId: 'year-1',
+      title: 'Test Survey',
+      surveyDates: [{ date: 'invalid-date', grade: 'JUNIOR' }],
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('候補日の日付形式が不正です');
+  });
+
   it('should return 400 when surveyDate has invalid grade', async () => {
     const request = createMockRequest({
       schoolYearId: 'year-1',

--- a/src/app/api/surveys/route.ts
+++ b/src/app/api/surveys/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { Grade } from '@prisma/client';
+import type { Grade } from '@prisma/client';
+
+const VALID_GRADES: Grade[] = ['JUNIOR', 'MIDDLE', 'SENIOR'];
 
 interface SurveyDateInput {
   date: string; // ISO 8601 format
@@ -69,7 +71,11 @@ export async function POST(request: NextRequest) {
       if (!surveyDate.date) {
         return NextResponse.json({ error: '候補日の日付を入力してください' }, { status: 400 });
       }
-      if (!surveyDate.grade || !Object.values(Grade).includes(surveyDate.grade)) {
+      const parsedDate = new Date(surveyDate.date);
+      if (Number.isNaN(parsedDate.getTime())) {
+        return NextResponse.json({ error: '候補日の日付形式が不正です' }, { status: 400 });
+      }
+      if (!surveyDate.grade || !VALID_GRADES.includes(surveyDate.grade)) {
         return NextResponse.json({ error: '候補日の対象学年を選択してください' }, { status: 400 });
       }
     }


### PR DESCRIPTION
## Summary
- validate survey date inputs with explicit grade constants and date format checking
- return clear 400 errors when survey dates are missing or malformed
- add test coverage for invalid survey date formats

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b7ee5f16c8323a2081c897783c44b)